### PR TITLE
Add canonical link to base layout

### DIFF
--- a/themes/m10c-27-02-2024/layouts/_default/baseof.html
+++ b/themes/m10c-27-02-2024/layouts/_default/baseof.html
@@ -8,6 +8,7 @@
     <meta name="viewport" content="width=device-width, initial-scale=1" />
     <meta name="author" content="{{ .Site.Params.author | default "John Doe" }}" />
     <meta name="description" content="{{ if .IsHome }}{{ .Site.Params.description }}{{ else }}{{ .Description }}{{ end }}" />
+    <link rel="canonical" href="{{ .Permalink }}" />
     {{ $style := resources.Get "css/main.scss" | resources.ExecuteAsTemplate "css/main.scss" . | css.Sass | resources.Minify | resources.Fingerprint -}}
     <link rel="stylesheet" href="{{ $style.RelPermalink }}" />
     {{ with .OutputFormats.Get "rss" -}}


### PR DESCRIPTION
## Summary
- add canonical link tag to base layout

## Testing
- `hugo`


------
https://chatgpt.com/codex/tasks/task_e_68c6f0f8586c832184f0a01521392b10